### PR TITLE
Fix java version to 1.8.0.144

### DIFF
--- a/jenkins-slave/Dockerfile
+++ b/jenkins-slave/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:27
 RUN dnf update -y \
     && groupadd --gid 995 jenkins \
     && groupadd --gid 1004 docker \
-    && dnf install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk-headless \
+    && dnf install -y java-1.8.0-openjdk-devel-1.8.0.144 java-1.8.0-openjdk-headless-1.8.0.144 \
     && dnf install -y nano bzip2 unzip zip iproute wget python gcc-c++ \
     && dnf install -y docker \
     && dnf install -y nodejs git \


### PR DESCRIPTION
Wildfly Maven Plugin has an [issue](https://issues.jboss.org/browse/WFMP-94) w/ Java 8 u161 so Java version for building has been fixed to u144